### PR TITLE
build: Use SPDX license

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('speech-provider-espeak',
         'rust',
         version: files('VERSION'),
-        license: 'GPL3',
+        license: 'GPL-3.0-or-later',
 	meson_version : '>= 0.58')
 
 dependency('glib-2.0', version: '>= 2.56')


### PR DESCRIPTION
This is recommended by Meson https://mesonbuild.com/Reference-manual_functions.html#project_license Matches the license in AppStream file.